### PR TITLE
✨[FEAT] #18:  홈화면 카테고리별 프로젝트 조회 API

### DIFF
--- a/src/main/java/umc/team4/domain/project/controller/ProjectRestController.java
+++ b/src/main/java/umc/team4/domain/project/controller/ProjectRestController.java
@@ -1,6 +1,8 @@
 package umc.team4.domain.project.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import umc.team4.common.exception.GeneralException;
@@ -8,6 +10,7 @@ import umc.team4.common.response.ApiResponse;
 import umc.team4.common.status.ErrorStatus;
 import umc.team4.common.status.SuccessStatus;
 import umc.team4.domain.project.dto.ProjectResponseDto;
+import umc.team4.domain.project.entity.Category;
 import umc.team4.domain.project.service.ProjectService;
 
 import java.util.List;
@@ -18,6 +21,16 @@ import java.util.List;
 public class ProjectRestController {
 
     private final ProjectService projectService;
+
+    @GetMapping("/lists")
+    public ResponseEntity<ApiResponse> getProjectsListByCategory(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam Category category
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        return projectService.getListByCategory(category, pageable);
+    }
 
     @GetMapping("/{projectId}")
     public ResponseEntity<ApiResponse> getProjectInfo(

--- a/src/main/java/umc/team4/domain/project/dto/ProjectResponseDto.java
+++ b/src/main/java/umc/team4/domain/project/dto/ProjectResponseDto.java
@@ -67,6 +67,7 @@ public class ProjectResponseDto {
         private String category;
         private Long currentAmount;
         private Long targetAmount;
+        private String percentage;
         private LocalDate endDate;
     }
 

--- a/src/main/java/umc/team4/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/umc/team4/domain/project/repository/ProjectRepository.java
@@ -1,9 +1,11 @@
 package umc.team4.domain.project.repository;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import umc.team4.domain.project.entity.Category;
 import umc.team4.domain.project.entity.Project;
 import umc.team4.domain.user.entity.User;
 
@@ -14,4 +16,5 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
     @Query("SELECT p FROM Project p WHERE p.endDate >= CURRENT_DATE ORDER BY function('RAND')")
     List<Project> findRandomFiveProjects(Pageable pageable);
 
+    Page<Project> findByCategory(Category category, Pageable pageable);
 }

--- a/src/main/java/umc/team4/domain/project/service/ProjectService.java
+++ b/src/main/java/umc/team4/domain/project/service/ProjectService.java
@@ -1,6 +1,11 @@
 package umc.team4.domain.project.service;
 
+import org.apache.coyote.Response;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import umc.team4.common.response.ApiResponse;
 import umc.team4.domain.project.dto.ProjectResponseDto;
+import umc.team4.domain.project.entity.Category;
 
 import java.util.List;
 
@@ -11,4 +16,5 @@ public interface ProjectService {
     ProjectResponseDto.ProjectRewardDto getProjectRewards(Long projectId);
 
     List<ProjectResponseDto.ProjectSummaryDto> getRandomProjects();
+    ResponseEntity<ApiResponse> getListByCategory(Category category, Pageable pageable);
 }


### PR DESCRIPTION
## #⃣ 연관된 이슈

> close #18 

## 📝 작업 내용

- 홈화면에서 프로젝트 카테고리별로 목록 조회하는 API 구현했습니다.
- 페이지네이션 포함

### 📸 스크린샷 (선택)
<img width="710" alt="image" src="https://github.com/user-attachments/assets/4ca69096-5153-4a2f-954a-1eca205c4f10" />


